### PR TITLE
fix formatting

### DIFF
--- a/docs/ai/open-webui/os-installs/mint.md
+++ b/docs/ai/open-webui/os-installs/mint.md
@@ -67,7 +67,7 @@ pip install -U open-webui
 
 ## Install pyenv:
 ### Install git and curl
-```
+```
 sudo apt install git
 ```
 

--- a/docs/ai/open-webui/os-installs/oracle.md
+++ b/docs/ai/open-webui/os-installs/oracle.md
@@ -97,7 +97,7 @@ exec "$SHELL"
 ### Version check
 ```
 pyenv --version
-```
+```
 
 ### Look for Python versions
 ```
@@ -195,14 +195,14 @@ conda activate owui
 ### Verify Python version in the new environment
 ```
 python --version
-```
+```
 
 You should see output showing Python 3.11.11.
 
 ### Install Open WebUI
 ```
 pip install open-webui
-```
+```
 
 ### Start Open WebUI
 ```

--- a/docs/ai/open-webui/os-installs/ubuntu.md
+++ b/docs/ai/open-webui/os-installs/ubuntu.md
@@ -120,7 +120,7 @@ pip install --upgrade pip
 ### Install Open WebUI
 ```
 pip install open-webui
-```
+```
 
 ### Start Open WebUI
 ```
@@ -182,12 +182,12 @@ conda create --name owui python=3.11.11
 ### Activate the new environment
 ```
 conda activate owui
-```
+```
 
 ### Verify Python version in the new environment
 ```
 python --version
-```
+```
 
 You should see output showing Python 3.11.11.
 


### PR DESCRIPTION
This pull request includes several changes to improve the documentation for installing Open WebUI on different operating systems by fixing formatting issues (there is a funky character).

Formatting fixes in installation guides:

* [`docs/ai/open-webui/os-installs/mint.md`](diffhunk://#diff-e361fdcbb5f59a8d57283232626464e2e1d9a930418e5ee6568698f6ebf694aeL70-R70): Corrected the code block formatting for the command `sudo apt install git`.
* [`docs/ai/open-webui/os-installs/oracle.md`](diffhunk://#diff-ce64c8343194f6e3a7e71f6fc4249d1efa7ef6c01fb33734078f4e15772efa35L100-R100): Corrected the code block formatting for the commands `pyenv --version` and `python --version`, and for the sections on installing and starting Open WebUI. [[1]](diffhunk://#diff-ce64c8343194f6e3a7e71f6fc4249d1efa7ef6c01fb33734078f4e15772efa35L100-R100) [[2]](diffhunk://#diff-ce64c8343194f6e3a7e71f6fc4249d1efa7ef6c01fb33734078f4e15772efa35L198-R205)
* [`docs/ai/open-webui/os-installs/ubuntu.md`](diffhunk://#diff-0d6ec43283a63c3c8cdc24e412662aa2ea9da9ab09d0f48c602594670673504aL123-R123): Corrected the code block formatting for the sections on installing and starting Open WebUI, and verifying the Python version in the new environment. [[1]](diffhunk://#diff-0d6ec43283a63c3c8cdc24e412662aa2ea9da9ab09d0f48c602594670673504aL123-R123) [[2]](diffhunk://#diff-0d6ec43283a63c3c8cdc24e412662aa2ea9da9ab09d0f48c602594670673504aL185-R190)